### PR TITLE
Stabilize android builds

### DIFF
--- a/build/build-android-package.ps1
+++ b/build/build-android-package.ps1
@@ -40,6 +40,8 @@ function BuildAndroidApp($AndroidProject, $BuildConfiguration, $ExcludeExtension
             "/p:VersionCode=$VersionCode"
             "/p:ApkOutputPath=$([System.IO.Path]::GetFullPath($OutFileName))"
             "/restore"
+            "/m:1"
+            "/p:XamarinBuildDownloadAllowUnsecure=true"
 
             if(-not $NoCleanUp.IsPresent) {
                 '/t:Clean;SignAndroidPackage;MoveApkFile'


### PR DESCRIPTION
/m:1 - to ensure that android packages pulled and builded in one thread
/XamarinBuildDownloadAllowUnsecure=true to remove flacky errors with Xamarin.Build.dll