### PR TITLE
Simplify metric for statefull interviews cache Counter

### DIFF
--- a/src/Infrastructure/WB.Infrastructure.Native/Monitoring/CommonMetrics.cs
+++ b/src/Infrastructure/WB.Infrastructure.Native/Monitoring/CommonMetrics.cs
@@ -3,8 +3,8 @@
     public static class CommonMetrics
     {
         public static Counter WebInterviewConnection = new Counter("wb_webinterview_connections_total", "Number of times connection were open (open/closed), (review,takenew,web)", "action", "mode");
-        public static Counter StatefullInterviewCached = new Counter("wb_statefullinterview_cache_create", "Total number of times statefull interview cached");
-        public static Counter StatefullInterviewEvicted = new Counter("wb_statefullinterview_cache_evict", "Total number of times statefull interview cached", "reason");
+        public static Counter StatefullInterviewsCached = new Counter("wb_statefullinterview_cached_total", "Total number of times statefull interview cached (added/removed)", "action");
+        
         public static Counter StatefullInterviewCacheHit = new Counter("wb_statefullinterview_cache_hit", "Total number of times statefull interview cache hit");
         public static Counter StatefullInterviewCacheMiss = new Counter("wb_statefullinterview_cache_miss", "Total number of times statefull interview cache missed");
 

--- a/src/Infrastructure/WB.Infrastructure.Native/Storage/EventSourcedAggregateRootRepositoryWithWebCache.cs
+++ b/src/Infrastructure/WB.Infrastructure.Native/Storage/EventSourcedAggregateRootRepositoryWithWebCache.cs
@@ -116,7 +116,7 @@ namespace WB.Infrastructure.Native.Storage
                 SlidingExpiration = Expiration
             });
 
-            CommonMetrics.StatefullInterviewCached.Inc();
+            CommonMetrics.StatefullInterviewsCached.Labels("added").Inc();
         }
 
         private void OnUpdateCallback(CacheEntryRemovedArguments arguments)
@@ -128,7 +128,7 @@ namespace WB.Infrastructure.Native.Storage
 
         protected virtual void CacheItemRemoved(string key, CacheEntryRemovedReason reason)
         {
-            CommonMetrics.StatefullInterviewEvicted.Labels(reason.ToString()).Inc();
+            CommonMetrics.StatefullInterviewsCached.Labels("removed").Inc();
         }
 
         public void Evict(Guid aggregateId)

--- a/src/UI/WB.UI.Headquarters.Core/Metrics/DashboardStatisticsService.cs
+++ b/src/UI/WB.UI.Headquarters.Core/Metrics/DashboardStatisticsService.cs
@@ -57,8 +57,8 @@ namespace WB.UI.Headquarters.Metrics
             var cpuDiff = RegisterCounter(() => Process.GetCurrentProcess().TotalProcessorTime.TotalSeconds);
 
             // interviews cached/evicted change over time per second
-            var interviewsCached = RegisterCounter(() => CommonMetrics.StatefullInterviewCached.Value);
-            var interviewsEvicted = RegisterCounter(() => CommonMetrics.StatefullInterviewEvicted.GetSummForLabels());
+            var interviewsCached = RegisterCounter(() => CommonMetrics.StatefullInterviewsCached.GetSummForLabels(CacheAddedLabel));
+            var interviewsEvicted = RegisterCounter(() => CommonMetrics.StatefullInterviewsCached.GetSummForLabels(CacheRemovedLabel));
 
             // npgsql data transfer change over time  per second
             var dataTransferRead = RegisterCounter(() => CommonMetrics.NpgsqlDataCounter.GetSummForLabels(ReadDbdataLabel));
@@ -91,9 +91,9 @@ namespace WB.UI.Headquarters.Metrics
             result.Add(new MetricState("Web interview connections", "connection".ToQuantity(connections, "N0")));
 
             // statefull interviews
-            var statefulInterviews = CommonMetrics.StatefullInterviewCached.Value;
-            var evicted = CommonMetrics.StatefullInterviewEvicted.GetSummForLabels();
-            result.Add(new MetricState("Statefull interviews in cache", "interview".ToQuantity(statefulInterviews - evicted, "N0")
+            var statefulInterviews = CommonMetrics.StatefullInterviewsCached.GetDiffForLabels(CacheAddedLabel, CacheRemovedLabel);
+
+            result.Add(new MetricState("Statefull interviews in cache", "interview".ToQuantity(statefulInterviews, "N0")
                     + $" (cached {await interviewsCached:N2} / evicted {await interviewsEvicted:N2} per second)"));
 
             // exceptions
@@ -120,6 +120,8 @@ namespace WB.UI.Headquarters.Metrics
 
         private static readonly string[] OpenConnectionsLabel = { "open" };
         private static readonly string[] ClosedConnectionsLabel = { "closed" };
+        private static readonly string[] CacheAddedLabel = { "added" };
+        private static readonly string[] CacheRemovedLabel = { "removed" };
         private static readonly string[] IdleDbConnectionsLabel = { "idle" };
         private static readonly string[] BusyDbConnectionsLabel = { "busy" };
         private static readonly string[] ReadDbdataLabel = { "read" };


### PR DESCRIPTION
It seems that single metric is much more consistent in prometheus queries

Previous diff between older StatefullInterviewsCached metrics with different dimensions cause
   too much hassle on Grafana side to render them correctly
   and event then metric can go negative, when application go offline