### PR TITLE
Fix for concurrent execution of Export jobs

### DIFF
--- a/src/Services/Core/WB.Services.Scheduler/Services/Implementation/JobExecutor.cs
+++ b/src/Services/Core/WB.Services.Scheduler/Services/Implementation/JobExecutor.cs
@@ -54,6 +54,12 @@ namespace WB.Services.Scheduler.Services.Implementation
                     {
                         await using var tr = await db.Database.BeginTransactionAsync(token);
 
+                        if (!await db.TryAcquireLockAsync(job.Id))
+                        {
+                            logger.LogWarning("Job {jobId} is already in process", job.Id);
+                            return;
+                        }
+
                         var exportJob = serviceProvider.GetService(runner) as IJob;
 
                         if (exportJob == null)


### PR DESCRIPTION
Concurrent execution seems to be initiated by cleanup service.
Additional lock on job will prevent it from running

![image](https://user-images.githubusercontent.com/118516/79337799-e1b24000-7f2e-11ea-9d57-85473d27921d.png)
