### PR TITLE
Fixed Export Service estimation calculation and progress reporting

### DIFF
--- a/src/Core/Infrastructure/WB.Core.Infrastructure/Ncqrs/Eventing/Storage/IHeadquartersEventStore.cs
+++ b/src/Core/Infrastructure/WB.Core.Infrastructure/Ncqrs/Eventing/Storage/IHeadquartersEventStore.cs
@@ -24,7 +24,7 @@ namespace Ncqrs.Eventing.Storage
 
         int? GetMaxEventSequenceWithAnyOfSpecifiedTypes(Guid eventSourceId, params string[] typeNames);
 
-        IEnumerable<RawEvent> GetRawEventsFeed(long startWithGlobalSequence, int pageSize);
+        IEnumerable<RawEvent> GetRawEventsFeed(long startWithGlobalSequence, int pageSize, long limitSize = long.MaxValue);
 
         Task<long> GetMaximumGlobalSequence();
 

--- a/src/Tests/WB.Tests.Integration/PostgreSQLEventStoreTests/when_appending_events_with_wrong_expected_version.cs
+++ b/src/Tests/WB.Tests.Integration/PostgreSQLEventStoreTests/when_appending_events_with_wrong_expected_version.cs
@@ -2,7 +2,9 @@ using System;
 using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
+using Amazon.Runtime.Internal.Util;
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Ncqrs.Eventing;
 using Ncqrs.Eventing.Storage;
@@ -33,7 +35,8 @@ namespace WB.Tests.Integration.PostgreSQLEventStoreTests
 
             eventStore = new PostgresEventStore(
                 eventTypeResolver,
-                sessionProvider.Object);
+                sessionProvider.Object,
+                Mock.Of<ILogger<PostgresEventStore>>());
         }
 
         [SetUp]

--- a/src/Tests/WB.Tests.Integration/PostgreSQLEventStoreTests/when_stroring_event.cs
+++ b/src/Tests/WB.Tests.Integration/PostgreSQLEventStoreTests/when_stroring_event.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Ncqrs.Eventing;
 using Ncqrs.Eventing.Storage;
@@ -61,7 +62,8 @@ namespace WB.Tests.Integration.PostgreSQLEventStoreTests
 
             eventStore = new PostgresEventStore(
                 eventTypeResolver,
-                sessionProvider.Object);
+                sessionProvider.Object,
+                Mock.Of<ILogger<PostgresEventStore>>());
 
             BecauseOf();
         }

--- a/src/Tests/WB.Tests.Integration/PostgreSQLEventStoreTests/when_two_threads_storing_events.cs
+++ b/src/Tests/WB.Tests.Integration/PostgreSQLEventStoreTests/when_two_threads_storing_events.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Ncqrs.Eventing;
 using Ncqrs.Eventing.Storage;
@@ -178,7 +179,7 @@ namespace WB.Tests.Integration.PostgreSQLEventStoreTests
             sessionProvider.Setup(x => x.Session)
                 .Returns(Mock.Of<ISession>(i => i.Connection == connection));
 
-            return new PostgresEventStore(eventTypeResolver, sessionProvider.Object);
+            return new PostgresEventStore(eventTypeResolver, sessionProvider.Object, Mock.Of<ILogger<PostgresEventStore>>());
         }
     }
 }

--- a/src/UI/WB.UI.Headquarters.Core/Controllers/Services/Export/EventsApiController.cs
+++ b/src/UI/WB.UI.Headquarters.Core/Controllers/Services/Export/EventsApiController.cs
@@ -54,7 +54,7 @@ namespace WB.UI.Headquarters.Controllers.Services.Export
                 await json.WritePropertyNameAsync(nameof(EventsFeedPage.Events));
                 await json.WriteStartArrayAsync();
 
-                var events = headquartersEventStore.GetRawEventsFeed(sequence, pageSize);
+                var events = headquartersEventStore.GetRawEventsFeed(sequence, pageSize, 400 * 1024 * 1024 /* 400 Mb */);
 
                 // writing events in stream "as is" without serialization/deserialization
                 // to reduce memory pressure in HQ writing JSON manually


### PR DESCRIPTION
Fixed several issues around export service.

Those fixes will not speed up `statin` export prepare state, but will ensure that both HQ and Export are consume moderate amount of RAM and don't fall with OOM exception.

## Large memory usage

This can and will happen for `statin` server due to very large event stream. HQ were reading several gigabyte of json into memory. Export Service quadrouple this amount to deserialize and forward read.

Fixed by limiting HQ response to around 400 Mb maximum.

## Wrong ETA report and percentage progress
Wrong ETA calculation lead to wrong batch duration calculation and wrong next batch size calculation. This lead to slow export progress



