### PR TITLE
KP-14146 Broken interview on interview key duplication

### DIFF
--- a/src/Infrastructure/WB.Infrastructure.Native/Storage/Postgre/OrmModule.cs
+++ b/src/Infrastructure/WB.Infrastructure.Native/Storage/Postgre/OrmModule.cs
@@ -162,7 +162,8 @@ namespace WB.Infrastructure.Native.Storage.Postgre
             // File.WriteAllText(@"D:\Temp\Mapping.xml" , Serialize(maps)); // Can be used to check mappings
 
             cfg.SessionFactory().GenerateStatistics();
-
+            cfg.SessionFactory().DefaultFlushMode(FlushMode.Commit);
+            
             var sessionFactory = cfg.BuildSessionFactory();
 
             return sessionFactory;


### PR DESCRIPTION
Setting default flush mode to `Commit`
This will disable NHibernate automatic session flush.