### PR TITLE
Fix clean database migrations

### DIFF
--- a/src/Infrastructure/WB.Persistence.Headquarters/Migrations/ReadSide/M2020/M202007141132_AddedTabletReceivedDateTime.cs
+++ b/src/Infrastructure/WB.Persistence.Headquarters/Migrations/ReadSide/M2020/M202007141132_AddedTabletReceivedDateTime.cs
@@ -11,7 +11,11 @@ namespace WB.Persistence.Headquarters.Migrations.ReadSide
                 .AsDateTime()
                 .Nullable();
             
-            Execute.Sql(@"update readside.interviewsummaries as isum
+            if (this.Schema.Schema("events").Exists())
+            {
+                if (this.Schema.Schema("events").Table("events").Exists())
+                {
+                    Execute.Sql(@"update readside.interviewsummaries as isum
                 set receivedbyintervieweratutc = (
 		        select e.""timestamp"" 
                     from events.events e 
@@ -20,7 +24,9 @@ namespace WB.Persistence.Headquarters.Migrations.ReadSide
                     limit 1
                         ) 
                 where isum.receivedbyinterviewer = true;");
-            
+                }
+            }
+
             Delete.Column("receivedbyinterviewer").FromTable("interviewsummaries");
         }
 


### PR DESCRIPTION
```
[10:34:15 ERR] Failed to migrate. Stopping application. WB.Infrastructure.Native.InitializationException: Exception of type 'WB.Infrastructure.Native.InitializationException' was thrown.
 ---> System.Exception: An error occurred executing the following sql:
update readside.interviewsummaries as isum
                set receivedbyintervieweratutc = (
                        select e."timestamp"
                    from events.events e
                        where isum.interviewid = e.eventsourceid and e.eventtype = 'InterviewReceivedByInterviewer'
                    order by eventsequence desc
                    limit 1
                        )
                where isum.receivedbyinterviewer = true;
The error was 42P01: relation "events.events" does not exist
```