### PR TITLE
Updated HTTP duration metrics to ignore hub connections

### DIFF
--- a/src/Core/SharedKernels/Enumerator/WB.Enumerator.Native/WebInterview/Services/WebInterviewLazyNotificationService.cs
+++ b/src/Core/SharedKernels/Enumerator/WB.Enumerator.Native/WebInterview/Services/WebInterviewLazyNotificationService.cs
@@ -6,6 +6,7 @@ using WB.Core.Infrastructure.Aggregates;
 using WB.Core.SharedKernels.DataCollection;
 using WB.Core.SharedKernels.DataCollection.Repositories;
 using WB.Enumerator.Native.WebInterview.Pipeline;
+using WB.Infrastructure.Native.Monitoring;
 
 namespace WB.Enumerator.Native.WebInterview.Services
 {
@@ -38,6 +39,7 @@ namespace WB.Enumerator.Native.WebInterview.Services
         {
             foreach (var action in deferQueue.GetConsumingEnumerable())
             {
+                CommonMetrics.WebInterviewNotifications.Dec();
                 try
                 {
                     InScopeExecutor.Current.Execute(action);
@@ -55,6 +57,7 @@ namespace WB.Enumerator.Native.WebInterview.Services
         {
             if (aggregateRootCache.GetConnectedCount(interviewId) > 0)
             {
+                CommonMetrics.WebInterviewNotifications.Inc();
                 deferQueue.Add(action);
             }
         }

--- a/src/Infrastructure/WB.Infrastructure.Native/Monitoring/CommonMetrics.cs
+++ b/src/Infrastructure/WB.Infrastructure.Native/Monitoring/CommonMetrics.cs
@@ -12,6 +12,7 @@ namespace WB.Infrastructure.Native.Monitoring
         }
 
         public static Counter WebInterviewConnection = new Counter("wb_webinterview_connections_total", "Number of times connection were open (open/closed), (review,takenew,web)", "action", "mode");
+        public static Gauge WebInterviewNotifications = new Gauge("wb_webinterview_notification_queue", "Web Interview notification queue depth");
         public static Gauge NpgsqlConnections = new Gauge("npgsql_connections_current", "Number of connections managed by Npgsql (idle/busy)", "type");
         public static Gauge NpgsqlConnectionsPoolCount = new Gauge("npgsql_connection_pools_current", "Number of connection pools managed by Npgsql");
         public static Counter NpgsqlDataCounter = new Counter("npgsql_data_bytes_total", "Amount of byte read/write by Npgsql", "direction");

--- a/src/UI/WB.UI.Headquarters.Core/Startup.cs
+++ b/src/UI/WB.UI.Headquarters.Core/Startup.cs
@@ -231,7 +231,7 @@ namespace WB.UI.Headquarters
             services.AddSession(options =>
             {
                 options.IdleTimeout = TimeSpan.FromMinutes(20);
-                options.Cookie.Name = "hq";
+                options.Cookie.Name = "headquarters_session";
                 options.Cookie.HttpOnly = true; 
                 options.Cookie.IsEssential = true;
             });


### PR DESCRIPTION
- Added notification queue depth metric
- Do not track `/interview` connection durtaion to SignalrR hub 
- Track `/interview` connections count to SignalrR hub with separate label