### PR TITLE
Automatically approve merge to master from rc/release and merge

### DIFF
--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -1,0 +1,19 @@
+name: Auto approve
+
+on:
+  pull_request
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: hmarr/auto-approve-action@v2.0.0
+      name: rc to master
+      if: ${{ github.event.pull_request.base.ref == 'master' && github.event.pull_request.head.ref == 'rc' }}
+      with:
+        github-token: "${{ secrets.GITHUB_TOKEN }}"
+    - uses: hmarr/auto-approve-action@v2.0.0
+      name: release to master
+      if: ${{ github.event.pull_request.base.ref == 'master' && github.event.pull_request.head.ref == 'release' }}
+      with:
+        github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -1,0 +1,36 @@
+name: automerge
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status: {}
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: automerge
+        uses: "pascalgn/automerge-action@f81beb99aef41bb55ad072857d43073fba833a98"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_LABELS: automerge
+          MERGE_REMOVE_LABELS: automerge
+          MERGE_METHOD: merge
+          MERGE_COMMIT_MESSAGE: "pull-request-description"
+          MERGE_FORKS: "false"
+          MERGE_RETRIES: "6"
+          MERGE_RETRY_SLEEP: "10000"
+          UPDATE_LABELS: ""
+          UPDATE_METHOD: "merge"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -23,3 +23,17 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: |
             rc
+        
+      - uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ github.event.pull_request.base.ref == 'master' && github.event.pull_request.head.ref == 'rc' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            automerge
+            
+      - uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ github.event.pull_request.base.ref == 'master' && github.event.pull_request.head.ref == 'release' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            automerge


### PR DESCRIPTION
- `Auto approve` action will automatically approve PR from `RC` to `master` and from `release` to `master`
- `Autolabeler` will add `automerge` label to all PR from `RC` to `master` and from `release` to `master`
- `automerge` action will automatiaclly merge PR with `automerge` label on them