### PR TITLE
KP-14335 HQ Wait for DB to be available

### DIFF
--- a/src/Core/Infrastructure/WB.Core.Infrastructure/Modularity/Autofac/AutofacKernel.cs
+++ b/src/Core/Infrastructure/WB.Core.Infrastructure/Modularity/Autofac/AutofacKernel.cs
@@ -103,7 +103,7 @@ namespace WB.Core.Infrastructure.Modularity.Autofac
                 try
                 {
                     await Policy.Handle<InitializationException>(e => e.IsTransient)
-                        .WaitAndRetryAsync(10, i => TimeSpan.FromSeconds(i),
+                        .WaitAndRetryForeverAsync(i => TimeSpan.FromSeconds(Math.Max(i, 5)),
                             (exception, span) => status.Run())
                         .ExecuteAsync(async () =>
                         {


### PR DESCRIPTION
https://www.postgresql.org/docs/12/errcodes-appendix.html

it's not possbile to identify which of those errors can be assumed as transient. 
Maybe we just should always retry. No matter what error it is. Even for authorization errors, as those can be fixed on DB side also