### PR TITLE
Fix typeahead to handle concurrent searches

### DIFF
--- a/src/UI/WB.UI.Frontend/src/webinterview/components/questions/ui/typeahead.vue
+++ b/src/UI/WB.UI.Frontend/src/webinterview/components/questions/ui/typeahead.vue
@@ -103,11 +103,11 @@ export default {
         loadOptions(filter) {
             this.isLoading = true
             this.lastFilter = filter
-            const currentFilter = filter
+            const requestFilter = filter
 
             return this.optionsSource(filter).then((options) => {
                 this.isLoading = false
-                if(this.lastFilter === currentFilter)
+                if(this.lastFilter === requestFilter)
                     this.options = options || []
             })
         },

--- a/src/UI/WB.UI.Frontend/src/webinterview/components/questions/ui/typeahead.vue
+++ b/src/UI/WB.UI.Frontend/src/webinterview/components/questions/ui/typeahead.vue
@@ -81,6 +81,7 @@ export default {
             searchTerm: '',
             options: [],
             isLoading: false,
+            lastFilter: '',
         }
     },
     methods: {
@@ -101,10 +102,13 @@ export default {
         },
         loadOptions(filter) {
             this.isLoading = true
+            this.lastFilter = filter
+            const currentFilter = filter
 
             return this.optionsSource(filter).then((options) => {
                 this.isLoading = false
-                this.options = options || []
+                if(this.lastFilter === currentFilter)
+                    this.options = options || []
             })
         },
         selectOption(value) {


### PR DESCRIPTION
During typing several requests are sent to the server to get suggestions. If the pre-last requests finishes later then the last one it overrides results.