### PR TITLE
Remove warning for double

### DIFF
--- a/src/UI/WB.UI.Frontend/src/webinterview/components/questions/Double.vue
+++ b/src/UI/WB.UI.Frontend/src/webinterview/components/questions/Double.vue
@@ -15,8 +15,7 @@
 
                                 digitGroupSeparator: groupSeparator,
                                 decimalCharacter: decimalSeparator,
-                                decimalPlaces: decimalPlacesCount,
-                                allowDecimalPadding: false
+                                decimalPlaces: decimalPlacesCount
                             }" />
                         <wb-remove-answer v-if="!isSpecialValueSelected" :on-remove="removeAnswer" />
                     </div>

--- a/src/UI/WB.UI.Frontend/src/webinterview/components/questions/TableRoster.Double.vue
+++ b/src/UI/WB.UI.Frontend/src/webinterview/components/questions/TableRoster.Double.vue
@@ -6,8 +6,7 @@
             maximumValue: '99999999999999.99999999999999',
             digitGroupSeparator: groupSeparator,
             decimalCharacter: decimalSeparator,
-            decimalPlaces: decimalPlacesCount,
-            allowDecimalPadding: false
+            decimalPlaces: decimalPlacesCount
         }" />
 </template>
 


### PR DESCRIPTION
fixing 
Warning: Setting 'allowDecimalPadding' to [false] will override the current 'decimalPlaces*' settings [5, 5 and 5].