### PR TITLE
Fix typos in Russian GPS provider error message

### DIFF
--- a/src/Core/SharedKernels/Enumerator/Enumerator/Properties/EnumeratorUIResources.ru.resx
+++ b/src/Core/SharedKernels/Enumerator/Enumerator/Properties/EnumeratorUIResources.ru.resx
@@ -1043,7 +1043,7 @@
     <value>Показать QR код</value>
   </data>
   <data name="Error_NoGpsProvider" xml:space="preserve">
-    <value>Не найдет GPS провайден на этом устройстве.</value>
+    <value>Не найден GPS провайдер на этом устройстве.</value>
   </data>
   <data name="Error_NoTargetAreaShapefile" xml:space="preserve">
     <value>Не найден файл границ для целейвой области.</value>


### PR DESCRIPTION
Fixes #4834.

The Russian string for `Error_NoGpsProvider` in `EnumeratorUIResources.ru.resx` contained two typos:

- `найдет` → `найден` (wrong verb form)
- `провайден` → `провайдер` ("provider")

Before:
> Не найдет GPS провайден на этом устройстве.

After:
> Не найден GPS провайдер на этом устройстве.

Single-line resource change, no code affected.
