### PR TITLE
Prevent invalid Interviewer picture uploads from returning HTTP 500

### DIFF
--- a/src/Tests/WB.Tests.Web/Headquarters/Controllers/InterviewerInterviewsControllerTests/v2/InterviewsApiV2ControllerTestsContext.cs
+++ b/src/Tests/WB.Tests.Web/Headquarters/Controllers/InterviewerInterviewsControllerTests/v2/InterviewsApiV2ControllerTestsContext.cs
@@ -28,7 +28,9 @@ namespace WB.Tests.Web.Headquarters.Controllers.InterviewerInterviewsControllerT
             IInterviewPackagesService incomingSyncPackagesQueue = null,
             ICommandService commandService = null,
             IMetaInfoBuilder metaBuilder = null,
-            IJsonAllTypesSerializer synchronizationSerializer =  null)
+            IJsonAllTypesSerializer synchronizationSerializer =  null,
+            IImageProcessingService imageProcessingService = null,
+            IBrokenImageFileStorage brokenImageFileStorage = null)
         {
             var interviewsApiV2Controller = new InterviewsApiV2Controller(
                 imageFileStorage: imageFileStorage ?? Mock.Of<IImageFileStorage>(),
@@ -43,8 +45,8 @@ namespace WB.Tests.Web.Headquarters.Controllers.InterviewerInterviewsControllerT
                 audioAuditFileStorage: audioAuditFileStorage ?? Mock.Of<IAudioAuditFileStorage>(),
                 userToDeviceService: Mock.Of<IUserToDeviceService>(),
                 webHostEnvironment: Mock.Of<IWebHostEnvironment>(),
-                imageProcessingService: Mock.Of<IImageProcessingService>(),
-                brokenImageFileStorage: Mock.Of<IBrokenImageFileStorage>(),
+                imageProcessingService: imageProcessingService ?? Mock.Of<IImageProcessingService>(),
+                brokenImageFileStorage: brokenImageFileStorage ?? Mock.Of<IBrokenImageFileStorage>(),
                 brokenAudioFileStorage: Mock.Of<IBrokenAudioFileStorage>(),
                 brokenAudioAuditFileStorage: Mock.Of<IBrokenAudioAuditFileStorage>());
 

--- a/src/Tests/WB.Tests.Web/Headquarters/Controllers/InterviewerInterviewsControllerTests/v2/when_posting_image_by_interview.cs
+++ b/src/Tests/WB.Tests.Web/Headquarters/Controllers/InterviewerInterviewsControllerTests/v2/when_posting_image_by_interview.cs
@@ -1,4 +1,6 @@
 using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Moq;
 using WB.Core.SharedKernel.Structures.Synchronization.SurveyManagement;
 using WB.Core.SharedKernels.DataCollection.Repositories;
@@ -12,11 +14,12 @@ namespace WB.Tests.Web.Headquarters.Controllers.InterviewerInterviewsControllerT
         public void context()
         {
             controller = CreateInterviewerInterviewsController(
-                imageFileStorage: mockOflainInterviewFileStorage.Object);
-            BecauseOf();
+                imageFileStorage: mockOflainInterviewFileStorage.Object,
+                imageProcessingService: imageProcessingService.Object);
+            result = BecauseOf();
         }
 
-        public void BecauseOf() => controller.PostImage(new PostFileRequest
+        public IActionResult BecauseOf() => controller.PostImage(new PostFileRequest
             {InterviewId = interviewId, FileName = imageFileName, Data = imageAsBase64String});
 
         [NUnit.Framework.Test]
@@ -24,12 +27,21 @@ namespace WB.Tests.Web.Headquarters.Controllers.InterviewerInterviewsControllerT
             mockOflainInterviewFileStorage.Verify(
                 x => x.StoreInterviewBinaryData(interviewId, imageFileName, imageBytes, null), Times.Once);
 
+        [NUnit.Framework.Test]
+        public void should_validate_image_once() =>
+            imageProcessingService.Verify(x => x.Validate(imageBytes), Times.Once);
+
+        [NUnit.Framework.Test]
+        public void should_return_no_content() =>
+            NUnit.Framework.Assert.That(((StatusCodeResult)result).StatusCode, NUnit.Framework.Is.EqualTo(StatusCodes.Status204NoContent));
 
         private static InterviewsApiV2Controller controller;
+        private static IActionResult result;
         private static readonly Guid interviewId = Guid.Parse("11111111111111111111111111111111");
         private static readonly string imageFileName = "image.png";
         private static readonly byte[] imageBytes = {1, 234, 21, 0, 54, 1, 66, 78};
         private static readonly string imageAsBase64String = Convert.ToBase64String(imageBytes);
         private static readonly Mock<IImageFileStorage> mockOflainInterviewFileStorage = new Mock<IImageFileStorage>();
+        private static readonly Mock<WB.UI.Shared.Web.Services.IImageProcessingService> imageProcessingService = new Mock<WB.UI.Shared.Web.Services.IImageProcessingService>();
     }
 }

--- a/src/Tests/WB.Tests.Web/Headquarters/Controllers/InterviewerInterviewsControllerTests/v2/when_posting_invalid_image_by_interview.cs
+++ b/src/Tests/WB.Tests.Web/Headquarters/Controllers/InterviewerInterviewsControllerTests/v2/when_posting_invalid_image_by_interview.cs
@@ -1,0 +1,56 @@
+using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using SixLabors.ImageSharp;
+using WB.Core.SharedKernel.Structures.Synchronization.SurveyManagement;
+using WB.Core.SharedKernels.DataCollection.Repositories;
+using WB.UI.Headquarters.Controllers.Api.DataCollection.Interviewer.v2;
+using WB.UI.Shared.Web.Services;
+
+namespace WB.Tests.Web.Headquarters.Controllers.InterviewerInterviewsControllerTests.v2
+{
+    [TestFixture]
+    internal class when_posting_invalid_image_by_interview : InterviewsApiV2ControllerTestsContext
+    {
+        [Test]
+        public void should_return_unsupported_media_type_and_not_store_image_when_format_is_unknown()
+        {
+            var imageStorage = new Mock<IImageFileStorage>();
+            var imageProcessingService = new Mock<IImageProcessingService>();
+            var brokenImageStorage = new Mock<IBrokenImageFileStorage>();
+            imageProcessingService.Setup(x => x.Validate(It.IsAny<byte[]>())).Throws(new UnknownImageFormatException("Unsupported image format"));
+            var controller = CreateInterviewerInterviewsController(imageFileStorage: imageStorage.Object, imageProcessingService: imageProcessingService.Object, brokenImageFileStorage: brokenImageStorage.Object);
+
+            var result = controller.PostImage(CreateRequest());
+
+            Assert.That(((StatusCodeResult)result).StatusCode, Is.EqualTo(StatusCodes.Status415UnsupportedMediaType));
+            imageStorage.Verify(x => x.StoreInterviewBinaryData(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<string>()), Times.Never);
+            brokenImageStorage.Verify(x => x.StoreInterviewBinaryData(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Test]
+        public void should_return_unsupported_media_type_and_not_store_image_when_content_is_invalid()
+        {
+            var imageStorage = new Mock<IImageFileStorage>();
+            var imageProcessingService = new Mock<IImageProcessingService>();
+            var brokenImageStorage = new Mock<IBrokenImageFileStorage>();
+            imageProcessingService.Setup(x => x.Validate(It.IsAny<byte[]>())).Throws(new InvalidImageContentException("Invalid image content"));
+            var controller = CreateInterviewerInterviewsController(imageFileStorage: imageStorage.Object, imageProcessingService: imageProcessingService.Object, brokenImageFileStorage: brokenImageStorage.Object);
+
+            var result = controller.PostImage(CreateRequest());
+
+            Assert.That(((StatusCodeResult)result).StatusCode, Is.EqualTo(StatusCodes.Status415UnsupportedMediaType));
+            imageStorage.Verify(x => x.StoreInterviewBinaryData(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<string>()), Times.Never);
+            brokenImageStorage.Verify(x => x.StoreInterviewBinaryData(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<string>()), Times.Never);
+        }
+
+        private static PostFileRequest CreateRequest() => new PostFileRequest
+        {
+            InterviewId = Guid.Parse("11111111111111111111111111111111"),
+            FileName = "image.jpg",
+            Data = Convert.ToBase64String(new byte[] { 1, 234, 21, 0, 54, 1, 66, 78 })
+        };
+    }
+}

--- a/src/UI/Shared/WB.UI.Shared.Enumerator/Services/Internals/PictureChooser.cs
+++ b/src/UI/Shared/WB.UI.Shared.Enumerator/Services/Internals/PictureChooser.cs
@@ -3,7 +3,6 @@ using Android.Media;
 using MvvmCross.Base;
 using Plugin.Media;
 using Plugin.Media.Abstractions;
-using WB.Core.GenericSubdomains.Portable.Tasks;
 using WB.Core.SharedKernels.Enumerator.Implementation.Services;
 using WB.Core.SharedKernels.Enumerator.Services;
 using WB.Core.SharedKernels.Enumerator.Utils;
@@ -55,8 +54,11 @@ namespace WB.UI.Shared.Enumerator.Services.Internals
             MediaImplementation androidMedia = new MediaImplementation();
             using (var originalMetadata = new ExifInterface(photo.FullPath))
             {
-                androidMedia.FixOrientationAndResizeAsync(photo.FullPath, storeCameraMediaOptions, originalMetadata)
-                    .WaitAndUnwrapException();    
+                var isProcessed = await androidMedia.FixOrientationAndResizeAsync(photo.FullPath, storeCameraMediaOptions, originalMetadata)
+                    .ConfigureAwait(false);
+
+                if (!isProcessed)
+                    return null;
             }
 
             return await photo.OpenReadAsync();

--- a/src/UI/WB.UI.Headquarters.Core/Controllers/Api/DataCollection/InterviewsControllerBase.cs
+++ b/src/UI/WB.UI.Headquarters.Core/Controllers/Api/DataCollection/InterviewsControllerBase.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Hosting;
 using Ncqrs.Eventing;
 using Ncqrs.Eventing.Storage;
+using SixLabors.ImageSharp;
 using WB.Core.BoundedContexts.Headquarters.Services;
 using WB.Core.BoundedContexts.Headquarters.Users;
 using WB.Core.BoundedContexts.Headquarters.Views;
@@ -155,7 +156,18 @@ namespace WB.UI.Headquarters.Controllers.Api.DataCollection
                 return BadRequest("Request is null");
             
             var bytes = Convert.FromBase64String(request.Data);
-            this.imageProcessingService.Validate(bytes);
+            try
+            {
+                this.imageProcessingService.Validate(bytes);
+            }
+            catch (UnknownImageFormatException)
+            {
+                return StatusCode(StatusCodes.Status415UnsupportedMediaType);
+            }
+            catch (InvalidImageContentException)
+            {
+                return StatusCode(StatusCodes.Status415UnsupportedMediaType);
+            }
             
             if (AllowWorkWithInterview(request.InterviewId))
                 this.imageFileStorage.StoreInterviewBinaryData(request.InterviewId, request.FileName, bytes, null);


### PR DESCRIPTION
## Problem

Interviewer can currently keep a camera file even when Android orientation/resize processing returns `false`. The file is then stored as a `.jpg` picture answer and retried during every synchronization.

On Headquarters, unsupported or corrupt image bytes reach `ImageProcessingService.Validate`, where ImageSharp throws `UnknownImageFormatException` or `InvalidImageContentException`. Those exceptions currently escape `PostImage`, produce HTTP 500, and prevent the interview from synchronizing. The failure occurs before regular/broken binary storage, so it is unrelated to S3 writes.

This was observed in production on Survey Solutions 25.12.03 with two Android devices, two questionnaires, two workspaces, and eight interviews. The same affected images failed deterministically across repeated synchronization attempts.

## Changes

- Honor the Boolean result of Android `FixOrientationAndResizeAsync`; when processing fails, do not open or persist the original camera file as a picture answer.
- Translate ImageSharp's unsupported/corrupt-image exceptions into HTTP 415 before either image-storage branch is reached.
- Preserve successful image validation, storage, and HTTP 204 behavior.
- Add focused controller tests for valid, unknown-format, and corrupt-image uploads, including assertions that rejected images are never written to regular or broken storage.

## Scope

This change intentionally does not add a speculative HEIC decoder or silently transcode production images because the original affected bytes were not available to confirm their format. It prevents new invalid camera answers and gives HQ a correct non-500 response. Recovery of interviews that already contain invalid local image bytes remains separate work.

## Validation

```text
dotnet test src/Tests/WB.Tests.Web/WB.Tests.Web.csproj \
  --filter "FullyQualifiedName~InterviewerInterviewsControllerTests.v2" \
  --no-restore --verbosity minimal

Passed: 8
Failed: 0
Skipped: 0
```

- Headquarters and the dependencies exercised by `WB.Tests.Web` compile under .NET 9.
- `git diff --check` passes.
- A fresh Sol/High review returned `ship` with no findings.
- Android compilation was not available on the verification host because it has no Android workload, Android SDK, or Java runtime. The changed call uses Xam.Plugin.Media 6.0.2's existing `Task<bool>` contract.
